### PR TITLE
Removed TransferOptions and related code

### DIFF
--- a/src/pcms/common.h
+++ b/src/pcms/common.h
@@ -7,8 +7,6 @@
 namespace pcms
 {
 using ProcessType = redev::ProcessType;
-class GatherOperation;
-class ScatterOperation;
 
 namespace detail
 {
@@ -56,12 +54,6 @@ auto find_many_or_error(const std::vector<T>& keys,
   return results;
 }
 } // namespace detail
-
-struct TransferOptions
-{
-  FieldTransferMethod transfer_method;
-  FieldEvaluationMethod evaluation_method;
-};
 } // namespace pcms
 
 #endif // PCMS_COUPLING_COMMON_H

--- a/src/pcms/field_evaluation_methods.h
+++ b/src/pcms/field_evaluation_methods.h
@@ -21,17 +21,6 @@ struct NearestNeighbor
 
 struct Copy{};
 
-enum class FieldTransferMethod {
-  None,
-  Interpolate,
-  Copy
-};
-enum class FieldEvaluationMethod {
-  None,
-  Lagrange1,
-  NearestNeighbor
-};
-
 } // namespace pcms
 
 #endif // PCMS_COUPLING_FIELD_EVALUATION_METHODS_H

--- a/src/pcms/omega_h_field.h
+++ b/src/pcms/omega_h_field.h
@@ -579,61 +579,6 @@ private:
   OmegaHField<T, CoordinateElementType> field_;
   mesh_entity_type entity_type_;
 };
-template <typename FieldAdapter>
-void ConvertFieldAdapterToOmegaH(const FieldAdapter& adapter,
-                                 InternalField internal,
-                                 FieldTransferMethod ftm,
-                                 FieldEvaluationMethod fem)
-{
-  PCMS_FUNCTION_TIMER;
-  std::visit(
-    [&](auto&& internal_field) {
-      transfer_field(adapter, internal_field, ftm, fem);
-    },
-    internal);
-}
-
-template <typename FieldAdapter>
-void ConvertOmegaHToFieldAdapter(const InternalField& internal,
-                                 FieldAdapter& adapter, FieldTransferMethod ftm,
-                                 FieldEvaluationMethod fem)
-{
-  PCMS_FUNCTION_TIMER;
-  std::visit(
-    [&](auto&& internal_field) {
-      transfer_field(internal_field, adapter, ftm, fem);
-    },
-    internal);
-}
-// Specializations for the Omega_h field adapter class since get/set are
-// implemented on the OmegaHFieldClass which is owned by the field adapter
-template <typename T, typename C>
-void ConvertFieldAdapterToOmegaH(const OmegaHFieldAdapter<T, C>& adapter,
-                                 InternalField internal,
-                                 FieldTransferMethod ftm,
-                                 FieldEvaluationMethod fem)
-{
-  PCMS_FUNCTION_TIMER;
-  std::visit(
-    [&](auto&& internal_field) {
-      transfer_field(adapter.GetField(), internal_field, ftm, fem);
-    },
-    internal);
-}
-template <typename T, typename C>
-void ConvertOmegaHToFieldAdapter(const InternalField& internal,
-                                 OmegaHFieldAdapter<T, C>& adapter,
-                                 FieldTransferMethod ftm,
-                                 FieldEvaluationMethod fem)
-{
-  PCMS_FUNCTION_TIMER;
-  std::visit(
-    [&](auto&& internal_field) {
-      transfer_field(internal_field, adapter.GetField(), ftm, fem);
-    },
-    internal);
-}
-
 } // namespace pcms
 
 #endif // PCMS_COUPLING_OMEGA_H_FIELD_H

--- a/src/pcms/server.h
+++ b/src/pcms/server.h
@@ -9,25 +9,6 @@
 
 namespace pcms
 {
-namespace detail
-{
-template <typename T, typename... Args>
-auto& find_or_create_internal_field(
-  const std::string& key, std::map<std::string, InternalField>& internal_fields,
-  Args&&... args)
-{
-  auto [it, inserted] = internal_fields.try_emplace(
-    key, std::in_place_type<OmegaHField<T, InternalCoordinateElement>>, key,
-    std::forward<Args>(args)...);
-  PCMS_ALWAYS_ASSERT(
-    (std::holds_alternative<OmegaHField<T, InternalCoordinateElement>>(
-      it->second)));
-  return it->second;
-}
-} // namespace detail
-using CombinerFunction = std::function<void(
-  nonstd::span<const std::reference_wrapper<InternalField>>, InternalField&)>;
-
 // TODO: come up with better name for this...Don't like CoupledFieldServer
 // because it's necessarily tied to the Server of the xgc_coupler
 class ConvertibleCoupledField
@@ -37,8 +18,6 @@ public:
   ConvertibleCoupledField(const std::string& name, FieldAdapterT field_adapter,
                           FieldCommunicator<CommT> field_comm,
                           Omega_h::Mesh& internal_mesh,
-                          TransferOptions native_to_internal,
-                          TransferOptions internal_to_native,
                           Omega_h::Read<Omega_h::I8> internal_field_mask = {})
     : internal_field_{OmegaHField<typename FieldAdapterT::value_type,
                                   InternalCoordinateElement>(
@@ -46,15 +25,12 @@ public:
   {
     PCMS_FUNCTION_TIMER;
     coupled_field_ = std::make_unique<CoupledFieldModel<FieldAdapterT, CommT>>(
-      std::move(field_adapter), std::move(field_comm),
-      std::move(native_to_internal), std::move(internal_to_native));
+      std::move(field_adapter), std::move(field_comm));
   }
   template <typename FieldAdapterT>
   ConvertibleCoupledField(const std::string& name, FieldAdapterT field_adapter,
                           MPI_Comm mpi_comm, redev::Redev& redev,
                           redev::Channel& channel, Omega_h::Mesh& internal_mesh,
-                          TransferOptions native_to_internal,
-                          TransferOptions internal_to_native,
                           Omega_h::Read<Omega_h::I8> internal_field_mask)
     : internal_field_{OmegaHField<typename FieldAdapterT::value_type,
                                   InternalCoordinateElement>(
@@ -63,8 +39,7 @@ public:
     PCMS_FUNCTION_TIMER;
     coupled_field_ =
       std::make_unique<CoupledFieldModel<FieldAdapterT, FieldAdapterT>>(
-        name, std::move(field_adapter), mpi_comm, redev, channel,
-        std::move(native_to_internal), std::move(internal_to_native));
+        name, std::move(field_adapter), mpi_comm, redev, channel);
   }
 
   void Send(Mode mode = Mode::Synchronous)
@@ -76,16 +51,6 @@ public:
   {
     PCMS_FUNCTION_TIMER;
     coupled_field_->Receive();
-  }
-  void SyncNativeToInternal()
-  {
-    PCMS_FUNCTION_TIMER;
-    coupled_field_->SyncNativeToInternal(internal_field_);
-  }
-  void SyncInternalToNative()
-  {
-    PCMS_FUNCTION_TIMER;
-    coupled_field_->SyncInternalToNative(internal_field_);
   }
   [[nodiscard]] InternalField& GetInternalField() noexcept
   {
@@ -112,8 +77,6 @@ public:
   {
     virtual void Send(Mode) = 0;
     virtual void Receive() = 0;
-    virtual void SyncNativeToInternal(InternalField&) = 0;
-    virtual void SyncInternalToNative(const InternalField&) = 0;
     [[nodiscard]] virtual const std::type_info& GetFieldAdapterType()
       const noexcept = 0;
     [[nodiscard]] virtual void* GetFieldAdapter() noexcept = 0;
@@ -125,27 +88,19 @@ public:
     using value_type = typename FieldAdapterT::value_type;
 
     CoupledFieldModel(FieldAdapterT&& field_adapter,
-                      FieldCommunicator<CommT>&& comm,
-                      TransferOptions&& native_to_internal,
-                      TransferOptions&& internal_to_native)
+                      FieldCommunicator<CommT>&& comm)
       : field_adapter_(std::move(field_adapter)),
         comm_(std::move(comm)),
-        native_to_internal_(std::move(native_to_internal)),
-        internal_to_native_(std::move(internal_to_native)),
         type_info_(typeid(FieldAdapterT))
     {
       PCMS_FUNCTION_TIMER;
     }
     CoupledFieldModel(const std::string& name, FieldAdapterT&& field_adapter,
                       MPI_Comm mpi_comm, redev::Redev& redev,
-                      redev::Channel& channel,
-                      TransferOptions&& native_to_internal,
-                      TransferOptions&& internal_to_native)
+                      redev::Channel& channel)
       : field_adapter_(std::move(field_adapter)),
         comm_(FieldCommunicator<FieldAdapterT>(name, mpi_comm, redev, channel,
                                                field_adapter_)),
-        native_to_internal_(std::move(native_to_internal)),
-        internal_to_native_(std::move(internal_to_native)),
         type_info_(typeid(FieldAdapterT))
     {
       PCMS_FUNCTION_TIMER;
@@ -160,20 +115,6 @@ public:
       PCMS_FUNCTION_TIMER;
       comm_.Receive();
     };
-    void SyncNativeToInternal(InternalField& internal_field) final
-    {
-      PCMS_FUNCTION_TIMER;
-      ConvertFieldAdapterToOmegaH(field_adapter_, internal_field,
-                                  native_to_internal_.transfer_method,
-                                  native_to_internal_.evaluation_method);
-    };
-    void SyncInternalToNative(const InternalField& internal_field) final
-    {
-      PCMS_FUNCTION_TIMER;
-      ConvertOmegaHToFieldAdapter(internal_field, field_adapter_,
-                                  internal_to_native_.transfer_method,
-                                  internal_to_native_.evaluation_method);
-    };
     virtual const std::type_info& GetFieldAdapterType() const noexcept
     {
       return type_info_;
@@ -185,8 +126,6 @@ public:
 
     FieldAdapterT field_adapter_;
     FieldCommunicator<CommT> comm_;
-    TransferOptions native_to_internal_;
-    TransferOptions internal_to_native_;
     const std::type_info& type_info_;
   };
 
@@ -219,18 +158,12 @@ public:
   template <typename FieldAdapterT>
   ConvertibleCoupledField* AddField(
     std::string name, FieldAdapterT&& field_adapter,
-    FieldTransferMethod to_field_transfer_method,
-    FieldEvaluationMethod to_field_eval_method,
-    FieldTransferMethod from_field_transfer_method,
-    FieldEvaluationMethod from_field_eval_method,
     Omega_h::Read<Omega_h::I8> internal_field_mask = {})
   {
     PCMS_FUNCTION_TIMER;
     auto [it, inserted] = fields_.template try_emplace(
       name, name, std::forward<FieldAdapterT>(field_adapter), mpi_comm_, redev_,
       channel_, internal_mesh_,
-      TransferOptions{to_field_transfer_method, to_field_eval_method},
-      TransferOptions{from_field_transfer_method, from_field_eval_method},
       internal_field_mask);
     if (!inserted) {
       std::cerr << "OHField with this name" << name << "already exists!\n";
@@ -304,96 +237,6 @@ private:
   std::map<std::string, ConvertibleCoupledField> fields_;
   Omega_h::Mesh& internal_mesh_;
 };
-class GatherOperation
-{
-public:
-  GatherOperation(std::vector<std::reference_wrapper<ConvertibleCoupledField>>
-                    fields_to_gather,
-                  InternalField& combined_field, CombinerFunction combiner)
-    : coupled_fields_(std::move(fields_to_gather)),
-      combined_field_(combined_field),
-      combiner_(std::move(combiner))
-  {
-    PCMS_FUNCTION_TIMER;
-    internal_fields_.reserve(coupled_fields_.size());
-    std::transform(coupled_fields_.begin(), coupled_fields_.end(),
-                   std::back_inserter(internal_fields_),
-                   [](ConvertibleCoupledField& fld) {
-                     return std::ref(fld.GetInternalField());
-                   });
-  }
-  void Run() const
-  {
-    PCMS_FUNCTION_TIMER;
-    for (auto& field : coupled_fields_) {
-      field.get().Receive();
-      field.get().SyncNativeToInternal();
-    }
-    combiner_(internal_fields_, combined_field_);
-  };
-
-private:
-  std::vector<std::reference_wrapper<ConvertibleCoupledField>> coupled_fields_;
-  std::vector<std::reference_wrapper<InternalField>> internal_fields_;
-  InternalField& combined_field_;
-  CombinerFunction combiner_;
-};
-class ScatterOperation
-{
-public:
-  ScatterOperation(std::vector<std::reference_wrapper<ConvertibleCoupledField>>
-                     fields_to_scatter,
-                   InternalField& combined_field)
-    : coupled_fields_(std::move(fields_to_scatter)),
-      combined_field_{combined_field}
-  {
-    PCMS_FUNCTION_TIMER;
-
-    internal_fields_.reserve(coupled_fields_.size());
-    std::transform(begin(coupled_fields_), end(coupled_fields_),
-                   std::back_inserter(internal_fields_),
-                   [](ConvertibleCoupledField& fld) {
-                     return std::ref(fld.GetInternalField());
-                   });
-  }
-  void Run() const
-  {
-    PCMS_FUNCTION_TIMER;
-    // possible we may need to add a splitter operation here.
-    // needed splitter(combined_field, internal_fields_);
-    // for current use case, we copy the combined field
-    // into application internal fields
-    std::visit(
-      [this](const auto& combined_field) {
-        for (auto& field : coupled_fields_) {
-          std::visit(
-            [&](auto& internal_field) {
-              constexpr bool can_copy = std::is_same_v<
-                typename std::remove_reference_t<
-                  std::remove_cv_t<decltype(combined_field)>>::value_type,
-                typename std::remove_reference_t<
-                  std::remove_cv_t<decltype(internal_field)>>::value_type>;
-              if constexpr (can_copy) {
-                copy_field(combined_field, internal_field);
-              } else {
-                interpolate_field(combined_field, internal_field);
-              }
-            },
-            field.get().GetInternalField());
-        }
-      },
-      combined_field_);
-    for (auto& field : coupled_fields_) {
-      field.get().SyncInternalToNative();
-      field.get().Send(Mode::Synchronous);
-    }
-  };
-
-private:
-  std::vector<std::reference_wrapper<ConvertibleCoupledField>> coupled_fields_;
-  std::vector<std::reference_wrapper<InternalField>> internal_fields_;
-  InternalField& combined_field_;
-};
 
 class CouplerServer
 {
@@ -424,90 +267,6 @@ public:
     return &(it->second);
   }
 
-  // here we take a string, not string_view since we need to search map
-  void ScatterFields(const std::string& name)
-  {
-    PCMS_FUNCTION_TIMER;
-    detail::find_or_error(name, scatter_operations_).Run();
-  }
-  // here we take a string, not string_view since we need to search map
-  void GatherFields(const std::string& name)
-  {
-    PCMS_FUNCTION_TIMER;
-    detail::find_or_error(name, gather_operations_).Run();
-  }
-  template <typename CombinedFieldT = Real>
-  [[nodiscard]] GatherOperation* AddGatherFieldsOp(
-    const std::string& name,
-    std::vector<std::reference_wrapper<ConvertibleCoupledField>> gather_fields,
-    const std::string& internal_field_name, CombinerFunction func,
-    Omega_h::Read<Omega_h::I8> mask = {}, std::string global_id_name = "")
-  {
-    PCMS_FUNCTION_TIMER;
-    static constexpr int search_nx = 10;
-    static constexpr int search_ny = 10;
-
-    auto& combined = detail::find_or_create_internal_field<CombinedFieldT>(
-      internal_field_name, internal_fields_, internal_mesh_, mask,
-      std::move(global_id_name), search_nx, search_ny);
-    auto [it, inserted] = gather_operations_.template try_emplace(
-      name, std::move(gather_fields), combined, std::move(func));
-    if (!inserted) {
-      std::cerr << "GatherOperation with this name" << name
-                << "already exists!\n";
-      std::terminate();
-    }
-    return &(it->second);
-  }
-  // template <typename CombinedFieldT = Real>
-  // [[nodiscard]]
-  // GatherOperation* AddGatherFieldsOp(
-  //   const std::string& name, const std::vector<std::string>&
-  //   fields_to_gather, const std::string& internal_field_name,
-  //   CombinerFunction func, Omega_h::Read<Omega_h::I8> mask = {}, std::string
-  //   global_id_name = "")
-  // {
-  //   auto gather_fields = detail::find_many_or_error(fields_to_gather,
-  //   fields_); return AddGatherFieldsOp(name, std::move(gather_fields),
-  //   internal_field_name,
-  //                    std::forward<CombinerFunction>(func), std::move(mask),
-  //                    std::move(global_id_name));
-  // }
-  template <typename CombinedFieldT = Real>
-  [[nodiscard]] ScatterOperation* AddScatterFieldsOp(
-    const std::string& name, const std::string& internal_field_name,
-    std::vector<std::reference_wrapper<ConvertibleCoupledField>> scatter_fields,
-    Omega_h::Read<Omega_h::I8> mask = {}, std::string global_id_name = "")
-  {
-    PCMS_FUNCTION_TIMER;
-    static constexpr int search_nx = 10;
-    static constexpr int search_ny = 10;
-
-    auto& combined = detail::find_or_create_internal_field<CombinedFieldT>(
-      internal_field_name, internal_fields_, internal_mesh_, mask,
-      std::move(global_id_name), search_nx, search_ny);
-    auto [it, inserted] = scatter_operations_.template try_emplace(
-      name, std::move(scatter_fields), combined);
-
-    if (!inserted) {
-      std::cerr << "Scatter with this name" << name << "already exists!\n";
-      std::terminate();
-    }
-    return &(it->second);
-  }
-  // template <typename CombinedFieldT = Real>
-  // [[nodiscard]]
-  // ScatterOperation* AddScatterFieldsOp(
-  //   const std::string& name, const std::string& internal_field_name,
-  //   const std::vector<std::string>& fields_to_scatter,
-  //   Omega_h::Read<Omega_h::I8> mask = {}, std::string global_id_name = "")
-  // {
-  //   auto scatter_fields =
-  //     detail::find_many_or_error(fields_to_scatter, fields_);
-  //   return AddScatterFieldsOp(name, internal_field_name,
-  //                      std::move(scatter_fields), std::move(mask),
-  //                      std::move(global_id_name));
-  // }
   [[nodiscard]] const redev::Partition& GetPartition() const noexcept
   {
     return redev_.GetPartition();
@@ -534,8 +293,6 @@ private:
   // these internal fields correspond to the "Combined" fields
   std::map<std::string, InternalField> internal_fields_;
   // gather and scatter operations have reference to internal fields
-  std::map<std::string, ScatterOperation> scatter_operations_;
-  std::map<std::string, GatherOperation> gather_operations_;
   std::map<std::string, Application> applications_;
   Omega_h::Mesh& internal_mesh_;
 };

--- a/src/pcms/transfer_field.h
+++ b/src/pcms/transfer_field.h
@@ -76,41 +76,6 @@ void interpolate_field(const SourceField& source_field,
     set_nodal_data(target_field, make_array_view(data));
   }
 }
-template <typename SourceField, typename TargetField>
-void transfer_field(const SourceField& source, TargetField& target,
-                    FieldTransferMethod transfer_method,
-                    FieldEvaluationMethod evaluation_method)
-{
-  PCMS_FUNCTION_TIMER;
-  switch (transfer_method) {
-    case FieldTransferMethod::None: return;
-    case FieldTransferMethod::Copy:
-      if constexpr(std::is_same_v<SourceField, TargetField>) {
-        copy_field(source, target);
-      }
-      else {
-        std::cerr<<"Source field and destination field must have same type to copy!\n";
-        std::abort();
-      }
-      return;
-    case FieldTransferMethod::Interpolate:
-      switch (evaluation_method) {
-        case FieldEvaluationMethod::None:
-          std::cerr << "Cannot interpolate field with no evaluation method!";
-          std::terminate();
-        case FieldEvaluationMethod::Lagrange1:
-          interpolate_field(source, target, Lagrange<1>{});
-          break;
-        case FieldEvaluationMethod::NearestNeighbor:
-          interpolate_field(source, target, NearestNeighbor{});
-          break;
-          // no default case for compiler error on missing cases
-      }
-      return;
-      // no default case for compiler error on missing transfer method
-  }
-}
-
 } // namespace pcms
 
 #endif // PCMS_COUPLING_TRANSFER_FIELD_H

--- a/test/test_proxy_coupling_xgc_server.cpp
+++ b/test/test_proxy_coupling_xgc_server.cpp
@@ -11,8 +11,6 @@ using pcms::ConstructRCFromOmegaHMesh;
 using pcms::Copy;
 using pcms::CouplerClient;
 using pcms::CouplerServer;
-using pcms::FieldEvaluationMethod;
-using pcms::FieldTransferMethod;
 using pcms::GO;
 using pcms::Lagrange;
 using pcms::make_array_view;
@@ -54,11 +52,7 @@ void xgc_coupler(MPI_Comm comm, Omega_h::Mesh& mesh, std::string_view cpn_file)
     auto field_adapter = pcms::XGCFieldAdapter<GO>(
       ss.str(), comm, make_array_view(data[i]), rc, ts::IsModelEntInOverlap{});
     fields.push_back(
-      application->AddField(ss.str(), std::move(field_adapter),
-                            FieldTransferMethod::Copy, // to Omega_h
-                            FieldEvaluationMethod::None,
-                            FieldTransferMethod::Copy, // from Omega_h
-                            FieldEvaluationMethod::None, is_overlap));
+      application->AddField(ss.str(), std::move(field_adapter), is_overlap));
   }
 
   do {
@@ -115,11 +109,7 @@ void omegah_coupler(MPI_Comm comm, Omega_h::Mesh& mesh,
     auto field_adapter =
       pcms::OmegaHFieldAdapter<GO>(ss.str(), mesh, is_overlap, numbering);
     fields.push_back(
-      application->AddField(ss.str(), std::move(field_adapter),
-                            FieldTransferMethod::Copy, // to Omega_h
-                            FieldEvaluationMethod::None,
-                            FieldTransferMethod::Copy, // from Omega_h
-                            FieldEvaluationMethod::None, is_overlap));
+      application->AddField(ss.str(), std::move(field_adapter), is_overlap));
   }
   do {
     application->ReceivePhase([&]() {

--- a/test/xgc_n0_coupling_server.cpp
+++ b/test/xgc_n0_coupling_server.cpp
@@ -10,8 +10,6 @@
 using pcms::Copy;
 using pcms::CouplerClient;
 using pcms::CouplerServer;
-using pcms::FieldEvaluationMethod;
-using pcms::FieldTransferMethod;
 using pcms::GO;
 using pcms::LO;
 using pcms::OmegaHFieldAdapter;
@@ -34,10 +32,7 @@ static pcms::ConvertibleCoupledField* AddField(pcms::Application *application, c
       return application->AddField(field_name.str(),
                    pcms::OmegaHFieldAdapter<pcms::Real>(
                    path+field_name.str(), mesh, is_overlap, numbering),
-                   FieldTransferMethod::Copy, // to Omega_h
-                   FieldEvaluationMethod::None,
-                   FieldTransferMethod::Copy, // from Omega_h
-                   FieldEvaluationMethod::None, is_overlap);
+                   is_overlap);
 }
 
 struct XGCAnalysis {


### PR DESCRIPTION
This pull request deletes the `TransferOptions` struct and related code.

Removed: `TransferOptions`, `GatherOperation`, `ScatterOperation`, `FieldTransferMethod`, `FieldEvaluationMethod`, `transfer_field`, `find_or_create_internal_field`, `ConvertFieldAdapterToOmegaH`, ...

`test/field_transfer_example.cpp` was modified to not test `GatherOperation`.