### PR TITLE
Multidimensional Uniform Grid

### DIFF
--- a/src/pcms/point_search.cpp
+++ b/src/pcms/point_search.cpp
@@ -182,7 +182,7 @@ namespace detail
  */
 struct GridTriIntersectionFunctor
 {
-  GridTriIntersectionFunctor(Omega_h::Mesh& mesh, Kokkos::View<UniformGrid[1]> grid)
+  GridTriIntersectionFunctor(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid)
     : mesh_(mesh),
       tris2verts_(mesh_.ask_elem_verts()),
       coords_(mesh_.coords()),
@@ -222,7 +222,7 @@ private:
   Omega_h::Mesh& mesh_;
   Omega_h::LOs tris2verts_;
   Omega_h::Reals coords_;
-  Kokkos::View<UniformGrid[1]> grid_;
+  Kokkos::View<Uniform2DGrid[1]> grid_;
 public:
   LO nelems_;
 };
@@ -230,7 +230,7 @@ public:
 // num_grid_cells should be result of grid.GetNumCells(), take as argument to avoid extra copy
 // of grid from gpu to cpu
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<UniformGrid[1]> grid, int num_grid_cells)
+construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells)
 {
   Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO> intersection_map{};
   auto f = detail::GridTriIntersectionFunctor{mesh, grid};
@@ -358,7 +358,7 @@ GridPointSearch::GridPointSearch(Omega_h::Mesh& mesh, LO Nx, LO Ny)
 {
   auto mesh_bbox = Omega_h::get_bounding_box<2>(&mesh);
   auto grid_h = Kokkos::create_mirror_view(grid_);
-  grid_h(0) = UniformGrid{.edge_length = {mesh_bbox.max[0] - mesh_bbox.min[0],
+  grid_h(0) = Uniform2DGrid{.edge_length = {mesh_bbox.max[0] - mesh_bbox.min[0],
                            mesh_bbox.max[1] - mesh_bbox.min[1]},
     .bot_left = {mesh_bbox.min[0], mesh_bbox.min[1]},
     .divisions = {Nx, Ny}};

--- a/src/pcms/point_search.h
+++ b/src/pcms/point_search.h
@@ -17,7 +17,7 @@ namespace pcms
 // used
 namespace detail {
 Kokkos::Crs<LO, Kokkos::DefaultExecutionSpace, void, LO>
-construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<UniformGrid[1]> grid, int num_grid_cells);
+construct_intersection_map(Omega_h::Mesh& mesh, Kokkos::View<Uniform2DGrid[1]> grid, int num_grid_cells);
 }
 KOKKOS_FUNCTION
 Omega_h::Vector<3> barycentric_from_global(
@@ -60,7 +60,7 @@ private:
   Omega_h::Adj tris2edges_adj_;
   Omega_h::Adj tris2verts_adj_;
   Omega_h::Adj edges2verts_adj_;
-  Kokkos::View<UniformGrid[1]> grid_{"uniform grid"};
+  Kokkos::View<Uniform2DGrid[1]> grid_{"uniform grid"};
   CandidateMapT candidate_map_;
   Omega_h::LOs tris2verts_;
   Omega_h::Reals coords_;

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -26,20 +26,18 @@ public:
   //[[nodiscard]] KOKKOS_INLINE_FUNCTION LO ClosestCellID(const T& point) const
   [[nodiscard]] KOKKOS_INLINE_FUNCTION LO ClosestCellID(const Omega_h::Vector<2>& point) const
   {
-    std::array<Real, dim> distance_within_grid{point[0] - bot_left[0],
-                                               point[1] - bot_left[1]};
-    std::array<LO, dim> indexes{-1, -1};
+    std::array<Real, dim> distance_within_grid;
+    std::transform(point.begin(), point.begin() + dim, bot_left.begin(),
+                   distance_within_grid.begin(), std::minus<>());
+    
+    std::array<LO, dim> indexes;
+    indexes.fill(-1);
+
     // note that the indexes refer to row/columns which have the opposite order
     // of the coordinates i.e. x,y
     for (int i = 0; i < dim; ++i) {
-      if (distance_within_grid[i] <= 0) {
-        indexes[dim - (i + 1)] = 0;
-      } else if (distance_within_grid[i] >= edge_length[i]) {
-        indexes[dim - (i + 1)] = divisions[i] - 1;
-      } else {
-        indexes[dim - (i + 1)] = 
-          static_cast<LO>(std::floor(distance_within_grid[i] * divisions[i]/edge_length[i]));
-      }
+      auto index = static_cast<LO>(std::floor(distance_within_grid[i] * divisions[i]/edge_length[i]));
+      indexes[dim - (i + 1)] = std::clamp(index, 0, divisions[i] - 1);
     }
     return GetCellIndex(indexes[0], indexes[1]);
   }

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -45,13 +45,20 @@ public:
 
   [[nodiscard]] KOKKOS_INLINE_FUNCTION AABBox<dim> GetCellBBOX(LO idx) const
   {
-    auto [i, j] = GetDimensionedIndex(idx);
-    std::array<Real, dim> half_width = {edge_length[0] / (2.0 * divisions[0]),
-                                        edge_length[1] / (2.0 * divisions[1])};
-    AABBox<dim> bbox{.center = {(2.0 * j + 1.0) * half_width[0]+bot_left[0],
-                                (2.0 * i + 1.0) * half_width[1]+bot_left[1]},
-                     .half_width = half_width};
-    return bbox;
+    auto index = GetDimensionedIndex(idx);
+    std::reverse(index.begin(), index.end());
+
+    std::array<Real, dim> half_width, center;
+
+    std::transform(edge_length.begin(), edge_length.end(), divisions.begin(), half_width.begin(), [](const Real edge_length, const LO division) {
+      return edge_length / division / 2;
+    });
+
+    for (int i = 0; i < dim; ++i) {
+      center[i] = (2.0 * index[i] + 1.0) * half_width[i] + bot_left[i];
+    }
+
+    return { .center = center, .half_width = half_width };
   }
 
   [[nodiscard]] KOKKOS_INLINE_FUNCTION std::array<LO, dim> GetDimensionedIndex(LO idx) const

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -39,7 +39,7 @@ public:
       auto index = static_cast<LO>(std::floor(distance_within_grid[i] * divisions[i]/edge_length[i]));
       indexes[dim - (i + 1)] = std::clamp(index, 0, divisions[i] - 1);
     }
-    return GetCellIndex(indexes[0], indexes[1]);
+    return GetCellIndex(indexes);
   }
   [[nodiscard]] KOKKOS_INLINE_FUNCTION AABBox<dim> GetCellBBOX(LO idx) const
   {
@@ -55,10 +55,16 @@ public:
   {
     return {idx / divisions[0], idx % divisions[0]};
   }
-  [[nodiscard]] KOKKOS_INLINE_FUNCTION LO GetCellIndex(LO i, LO j) const
+
+  [[nodiscard]] KOKKOS_INLINE_FUNCTION LO GetCellIndex(const std::array<LO, dim>& point) const
   {
-    OMEGA_H_CHECK(i >= 0 && j >= 0 && i < divisions[1] && j < divisions[0]);
-    return i * divisions[0] + j;
+    LO idx = 0;
+    for (int i = 0; i < dim -1; i++) {
+      idx += point[i] * divisions[i];
+    }
+
+    idx += point[dim - 1];
+    return idx;
   }
 };
 

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -53,9 +53,19 @@ public:
                      .half_width = half_width};
     return bbox;
   }
+
   [[nodiscard]] KOKKOS_INLINE_FUNCTION std::array<LO, dim> GetDimensionedIndex(LO idx) const
   {
-    return {idx / divisions[0], idx % divisions[0]};
+    LO stride = std::accumulate(divisions.begin(), std::prev(divisions.end()), 1, std::multiplies<LO>{});
+    std::array<LO, dim> result;
+
+    for (int i = 0; i < dim; ++i) {
+      result[i] = idx / stride;
+      idx -= result[i] * stride;
+      stride /= divisions[i];
+    }
+
+    return result;
   }
 
   [[nodiscard]] KOKKOS_INLINE_FUNCTION LO GetCellIndex(std::array<LO, dim> dimensionedIndex) const

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -6,10 +6,11 @@
 #include <numeric>
 namespace pcms
 {
+
+template <unsigned dim = 2>
 struct UniformGrid
 {
   // Make private?
-  static constexpr int dim = 2;
   std::array<Real, dim> edge_length;
   std::array<Real, dim> bot_left;
   std::array<LO, dim> divisions;
@@ -62,6 +63,9 @@ public:
     return i * divisions[0] + j;
   }
 };
+
+using Uniform2DGrid = UniformGrid<>;
+
 } // namespace pcms
 
 #endif // PCMS_COUPLING_UNIFORM_GRID_H

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -24,10 +24,10 @@ public:
   // take the view as a template because it might be a subview type
   //template <typename T>
   //[[nodiscard]] KOKKOS_INLINE_FUNCTION LO ClosestCellID(const T& point) const
-  [[nodiscard]] KOKKOS_INLINE_FUNCTION LO ClosestCellID(const Omega_h::Vector<2>& point) const
+  [[nodiscard]] KOKKOS_INLINE_FUNCTION LO ClosestCellID(const Omega_h::Vector<dim>& point) const
   {
     std::array<Real, dim> distance_within_grid;
-    std::transform(point.begin(), point.begin() + dim, bot_left.begin(),
+    std::transform(point.begin(), point.end(), bot_left.begin(),
                    distance_within_grid.begin(), std::minus<>());
     
     std::array<LO, dim> indexes;
@@ -56,14 +56,16 @@ public:
     return {idx / divisions[0], idx % divisions[0]};
   }
 
-  [[nodiscard]] KOKKOS_INLINE_FUNCTION LO GetCellIndex(const std::array<LO, dim>& point) const
+  [[nodiscard]] KOKKOS_INLINE_FUNCTION LO GetCellIndex(const std::array<LO, dim>& dimensionedIndex) const
   {
     LO idx = 0;
-    for (int i = 0; i < dim -1; i++) {
-      idx += point[i] * divisions[i];
+    LO stride = 1;
+
+    for (int i = dim - 1; i >= 0; --i) {
+      idx += dimensionedIndex[i] * stride;
+      stride *= divisions[dim - 1 - i];
     }
 
-    idx += point[dim - 1];
     return idx;
   }
 };

--- a/test/test_point_search.cpp
+++ b/test/test_point_search.cpp
@@ -6,7 +6,7 @@
 
 using pcms::AABBox;
 using pcms::barycentric_from_global;
-using pcms::UniformGrid;
+using pcms::Uniform2DGrid;
 
 TEST_CASE("global to local")
 {
@@ -136,9 +136,9 @@ TEST_CASE("construct intersection map")
   REQUIRE(mesh.dim() == 2);
   SECTION("grid bbox overlap")
   {
-    Kokkos::View<UniformGrid[1]> grid_d("uniform grid");
+    Kokkos::View<Uniform2DGrid[1]> grid_d("uniform grid");
     auto grid_h = Kokkos::create_mirror_view(grid_d);
-    grid_h(0) = UniformGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
+    grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {10, 10}};
     Kokkos::deep_copy(grid_d, grid_h);
     auto intersection_map = pcms::detail::construct_intersection_map(mesh, grid_d, grid_h(0).GetNumCells());
     // assert(cudaSuccess == cudaDeviceSynchronize());
@@ -147,9 +147,9 @@ TEST_CASE("construct intersection map")
   }
   SECTION("fine grid")
   {
-    Kokkos::View<UniformGrid[1]> grid_d("uniform grid");
+    Kokkos::View<Uniform2DGrid[1]> grid_d("uniform grid");
     auto grid_h = Kokkos::create_mirror_view(grid_d);
-    grid_h(0) = UniformGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
+    grid_h(0) = Uniform2DGrid{.edge_length{1, 1}, .bot_left = {0, 0}, .divisions = {60, 60}};
     Kokkos::deep_copy(grid_d, grid_h);
     // require number of candidates is >=1 and <=6
     auto intersection_map = pcms::detail::construct_intersection_map(mesh, grid_d, grid_h(0).GetNumCells());

--- a/test/test_uniform_grid.cpp
+++ b/test/test_uniform_grid.cpp
@@ -44,7 +44,7 @@ TEST_CASE("uniform grid")
     REQUIRE(l == 9);
   }
   SECTION("GetCellIndex") {
-    REQUIRE(0 == uniform_grid.GetCellIndex(0,0));
-    REQUIRE(119 == uniform_grid.GetCellIndex(11,9));
+    REQUIRE(0 == uniform_grid.GetCellIndex({0,0}));
+    REQUIRE(119 == uniform_grid.GetCellIndex({11,9}));
   }
 }

--- a/test/test_uniform_grid.cpp
+++ b/test/test_uniform_grid.cpp
@@ -36,10 +36,10 @@ TEST_CASE("uniform grid")
     }
   }
   SECTION("GetTwoDCellIndex") {
-    auto [i,j] = uniform_grid.GetTwoDCellIndex(0);
+    auto [i,j] = uniform_grid.GetDimensionedIndex(0);
     REQUIRE(i == 0);
     REQUIRE(j == 0);
-    auto [k,l] = uniform_grid.GetTwoDCellIndex(119);
+    auto [k,l] = uniform_grid.GetDimensionedIndex(119);
     REQUIRE(k == 11);
     REQUIRE(l == 9);
   }

--- a/test/test_uniform_grid.cpp
+++ b/test/test_uniform_grid.cpp
@@ -2,11 +2,11 @@
 #include <catch2/catch_approx.hpp>
 #include <pcms/uniform_grid.h>
 
-using pcms::UniformGrid;
+using pcms::Uniform2DGrid;
 
 TEST_CASE("uniform grid")
 {
-  UniformGrid uniform_grid{
+  Uniform2DGrid uniform_grid{
     .edge_length = {10, 12}, .bot_left = {0, 0}, .divisions = {10, 12}};
   REQUIRE(uniform_grid.GetNumCells() == 120);
   // Omega_h::Vector<2> point{0,0};


### PR DESCRIPTION
This pull request extends the `UniformGrid` to support an arbitrary number of dimensions. It replaces several 2D-only implementations with regards to indexing and bounding box generation while retaining compatibility with existing usage and test cases. A `Uniform2DGrid` convenience type alias was introduced to make porting existing usage easier.

Updates to grid structures and methods:

* [`src/pcms/point_search.cpp`](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L185-R185): Renamed `UniformGrid` to `Uniform2DGrid` in the `GridTriIntersectionFunctor` constructor, `construct_intersection_map` function, and `GridPointSearch` constructor. [[1]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L185-R185) [[2]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L225-R233) [[3]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L361-R361)
* [`src/pcms/point_search.h`](diffhunk://#diff-2ecd0755f40bfb74a7216b8c61a8778312ec405396f82f190f03390b61add67dL20-R20): Updated the `construct_intersection_map` function and `GridPointSearch` class to use `Uniform2DGrid`. [[1]](diffhunk://#diff-2ecd0755f40bfb74a7216b8c61a8778312ec405396f82f190f03390b61add67dL20-R20) [[2]](diffhunk://#diff-2ecd0755f40bfb74a7216b8c61a8778312ec405396f82f190f03390b61add67dL63-R63)
* [`src/pcms/uniform_grid.h`](diffhunk://#diff-d8de715ae86c08eaa20cb7871151b3f34c1040ec243778554360116410e37e9fR9-L12): Renamed `UniformGrid` to `Uniform2DGrid` and updated methods to be more flexible with dimensions. Added `GetDimensionedIndex` and improved `GetCellIndex` and `GetCellBBOX` methods to handle dynamic dimensions. [[1]](diffhunk://#diff-d8de715ae86c08eaa20cb7871151b3f34c1040ec243778554360116410e37e9fR9-L12) [[2]](diffhunk://#diff-d8de715ae86c08eaa20cb7871151b3f34c1040ec243778554360116410e37e9fL26-R97)

Updates to tests:

* [`test/test_point_search.cpp`](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caL9-R9): Updated test cases to use `Uniform2DGrid` instead of `UniformGrid`. [[1]](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caL9-R9) [[2]](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caL139-R141) [[3]](diffhunk://#diff-e467d59b116c1d13e0f7604011f0cf481b532ddd68ee2f2f674f35d8d9fd22caL150-R152)
* [`test/test_uniform_grid.cpp`](diffhunk://#diff-4f87d80a91c08611b074db79520b5380639b557c04faf52f6854f1132bc0890cL5-R9): Updated test cases to use `Uniform2DGrid` and modified tests for grid indexing methods. [[1]](diffhunk://#diff-4f87d80a91c08611b074db79520b5380639b557c04faf52f6854f1132bc0890cL5-R9) [[2]](diffhunk://#diff-4f87d80a91c08611b074db79520b5380639b557c04faf52f6854f1132bc0890cL39-R48)