### PR TITLE
Fix #169

### DIFF
--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -27,9 +27,11 @@ public:
   [[nodiscard]] KOKKOS_INLINE_FUNCTION LO ClosestCellID(const Omega_h::Vector<dim>& point) const
   {
     std::array<Real, dim> distance_within_grid;
-    std::transform(point.begin(), point.end(), bot_left.begin(),
-                   distance_within_grid.begin(), std::minus<>());
-    
+
+    for (int i = 0; i < dim; ++i) {
+      distance_within_grid[i] = point[i] - bot_left[i];
+    }
+
     std::array<LO, dim> indexes;
 
     for (auto& index : indexes) {
@@ -53,7 +55,12 @@ public:
   [[nodiscard]] KOKKOS_INLINE_FUNCTION AABBox<dim> GetCellBBOX(LO idx) const
   {
     auto index = GetDimensionedIndex(idx);
-    std::reverse(index.begin(), index.end());
+
+    for (size_t i = 0, j = index.size() - 1; i < j; ++i, --j) {
+      auto temp = index[i];
+      index[i] = index[j];
+      index[j] = temp;
+    }
 
     std::array<Real, dim> half_width, center;
 

--- a/src/pcms/uniform_grid.h
+++ b/src/pcms/uniform_grid.h
@@ -31,7 +31,10 @@ public:
                    distance_within_grid.begin(), std::minus<>());
     
     std::array<LO, dim> indexes;
-    indexes.fill(-1);
+
+    for (auto& index : indexes) {
+      index = -1;
+    }
 
     for (int i = 0; i < dim; ++i) {
       auto index = static_cast<LO>(std::floor(distance_within_grid[i] * divisions[i]/edge_length[i]));
@@ -39,7 +42,11 @@ public:
     }
     // note that the indexes refer to row/columns which have the opposite order
     // of the coordinates i.e. x,y
-    std::reverse(indexes.begin(), indexes.end());
+    for (size_t i = 0, j = indexes.size() - 1; i < j; ++i, --j) {
+      auto temp = indexes[i];
+      indexes[i] = indexes[j];
+      indexes[j] = temp;
+    }
     return GetCellIndex(indexes);
   }
 
@@ -50,9 +57,9 @@ public:
 
     std::array<Real, dim> half_width, center;
 
-    std::transform(edge_length.begin(), edge_length.end(), divisions.begin(), half_width.begin(), [](const Real edge_length, const LO division) {
-      return edge_length / division / 2;
-    });
+    for (int i = 0; i < dim; ++i) {
+      half_width[i] = edge_length[i] / divisions[i] / 2;
+    }
 
     for (int i = 0; i < dim; ++i) {
       center[i] = (2.0 * index[i] + 1.0) * half_width[i] + bot_left[i];
@@ -63,7 +70,10 @@ public:
 
   [[nodiscard]] KOKKOS_INLINE_FUNCTION std::array<LO, dim> GetDimensionedIndex(LO idx) const
   {
-    LO stride = std::accumulate(divisions.begin(), std::prev(divisions.end()), 1, std::multiplies<LO>{});
+    LO stride = 1;
+    for (std::size_t i = 0; i < divisions.size() - 1; ++i) {
+      stride *= divisions[i];
+    }
     std::array<LO, dim> result;
 
     for (int i = 0; i < dim; ++i) {
@@ -79,7 +89,11 @@ public:
   {
     // note that the indexes refer to row/columns which have the opposite order
     // of the coordinates i.e. x,y
-    std::reverse(dimensionedIndex.begin(), dimensionedIndex.end());
+    for (size_t i = 0, j = dimensionedIndex.size() - 1; i < j; ++i, --j) {
+      auto temp = dimensionedIndex[i];
+      dimensionedIndex[i] = dimensionedIndex[j];
+      dimensionedIndex[j] = temp;
+    }
 
     LO idx = 0;
     LO stride = 1;


### PR DESCRIPTION
This pull addresses the issues found in #169. `UniformGrid` attempted to use STL algorithms, which were host-only, in a device context, resulting in the issues found. The STL algorithm's have been replaced with hand-rolled loops so that the device functions of `UniformGrid` now behave correctly. I've also moved the check for whether the point is inside the triangle to before the checks for nearest edge or vertex.

Changes to `src/pcms/point_search.cpp`:

* Simplified the loop and conditional logic in `GridPointSearch::operator()` by moving the barycentric inside check earlier and adding a break statement to exit the loop once a valid triangle is found. [[1]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L289-R300) [[2]](diffhunk://#diff-b6ad98d142d76056630fef89bd0d6d47d7f0dfb5b7944b7937c9410f08d479d0L341-L346)

Changes to `src/pcms/uniform_grid.h`:

* Replaced `std::transform` with a simple for loop to calculate `distance_within_grid` in `UniformGrid::ClosestCellID`.
* Replaced `indexes.fill(-1)` with a for loop to initialize indexes in `UniformGrid::ClosestCellID`.
* Replaced `std::reverse` with a manual reverse loop in `UniformGrid::ClosestCellID` and `UniformGrid::GetCellBBOX`. [[1]](diffhunk://#diff-d8de715ae86c08eaa20cb7871151b3f34c1040ec243778554360116410e37e9fL30-R69) [[2]](diffhunk://#diff-d8de715ae86c08eaa20cb7871151b3f34c1040ec243778554360116410e37e9fL82-R103)
* Replaced `std::accumulate` with a for loop to calculate the stride in `UniformGrid::GetDimensionedIndex`.