### PR TITLE
Fix CI workflow warning for incorrect `PrintError` usage

### DIFF
--- a/src/pcms/assert.h
+++ b/src/pcms/assert.h
@@ -25,6 +25,17 @@
       pcms::Pcms_Assert_Fail(omsg);                                            \
     }                                                                          \
   } while (0)
+#define PCMS_ALWAYS_ASSERT_3(cond, comm, msg)                                    \
+  do {                                                                        \
+    if (!(cond)) {                                                            \
+      int rank = -1;                                                          \
+      MPI_Comm_rank(comm, &rank);                                             \
+      char omsg[2048];                                                        \
+      snprintf(omsg, 2048, "%s failed at %s + %d on rank %d: %s\n", #cond,   \
+               __FILE__, __LINE__, rank, msg);                                \
+      pcms::Pcms_Assert_Fail(omsg);                                           \
+    }                                                                         \
+  } while (0)
 
 namespace pcms
 {

--- a/src/pcms/capi/client.cpp
+++ b/src/pcms/capi/client.cpp
@@ -9,7 +9,7 @@
 #include <fstream>
 #include "pcms/xgc_reverse_classification.h"
 #include "pcms/dummy_field_adapter.h"
-#include "pcms/print.h"
+#include "pcms/assert.h"
 namespace pcms
 {
 // Note that we have a closed set of types that can be used in the C interface
@@ -168,8 +168,7 @@ PcmsFieldAdapterHandle pcms_create_xgc_field_adapter(
                                                 in_overlap, *field_adapter);
       break;
     default:
-      pcms::printError("tyring to create XGC adapter with invalid type!\n");
-      std::abort();
+      pcms::Pcms_Assert_Fail("tyring to create XGC adapter with invalid type!\n");
   }
   return {reinterpret_cast<void*>(field_adapter)};
 }

--- a/src/pcms/capi/client.cpp
+++ b/src/pcms/capi/client.cpp
@@ -168,7 +168,7 @@ PcmsFieldAdapterHandle pcms_create_xgc_field_adapter(
                                                 in_overlap, *field_adapter);
       break;
     default:
-      pcms::Pcms_Assert_Fail("tyring to create XGC adapter with invalid type!\n");
+      PCMS_ALWAYS_ASSERT(false, MPI_COMM_WORLD, "tyring to create XGC adapter with invalid type!\n");
   }
   return {reinterpret_cast<void*>(field_adapter)};
 }


### PR DESCRIPTION
The format argument of `PrintError` is missing in `client.cpp`:
```
In file included from /home/runner/work/pcms/pcms/pcms/src/pcms/capi/client.cpp:12:
/home/runner/work/pcms/pcms/pcms/src/pcms/capi/../../pcms/print.h: In instantiation of ‘void pcms::printError(const char*, const Args& ...) [with Args = {}]’:
/home/runner/work/pcms/pcms/pcms/src/pcms/capi/client.cpp:171:23:   required from here
/home/runner/work/pcms/pcms/pcms/src/pcms/capi/../../pcms/print.h:31:10: warning: format not a string literal and no format arguments [-Wformat-security]
   31 |   fprintf(getStdout(), fmt, args...);
      |   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Proposed fix: Use `Pcms_Assert_Fail` to replace the `PrintError` and `abort`.