### PR TITLE
fix linking error on frontier with cray compiler wrappers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -149,7 +149,7 @@ endif ()
 if(PCMS_ENABLE_Fortran)
     add_executable(test_proxy_coupling_xgc_client_fortran test_proxy_coupling_xgc_client_fortran.f90)
     target_link_libraries(test_proxy_coupling_xgc_client_fortran PUBLIC pcms::fortranapi MPI::MPI_Fortran)
-    set_target_properties(test_proxy_coupling_xgc_client_fortran PROPERTIES LINKER_LANGUAGE CXX)
+    set_target_properties(test_proxy_coupling_xgc_client_fortran PROPERTIES LINKER_LANGUAGE Fortran)
     if(HOST_NPROC GREATER_EQUAL 4)
         dual_mpi_test(TESTNAME xgc_fortran_proxy_to_omega
                 TIMEOUT 10


### PR DESCRIPTION
This PR resolves the following error hit on Frontier when building with the Cray compiler wrappers.


```
 87%] Linking CXX executable test_proxy_coupling_xgc_client_fortran
cd /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/pcms/test && /usr/bin/cmake -E cmake_link_script CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/link.txt --verbose=1
/opt/cray/pe/craype/2.7.33/bin/CC -O3 -DNDEBUG -DNDEBUG -Wl,-rpath=/sw/frontier/spack-envs/cpe24.11-cpu/opt/cce-18.0.1/darshan-runtime-3.4.6-ymnx2jlqwdsmjgdiu6ldpyxmcenq2nks/lib -Wl,-no-as-needed -L/opt/rocm-6.2.4/lib/rocprofiler -L/opt/rocm-6.2.4/lib/roctracer -L/autofs/nccs-svm1_sw/frontier/spack-envs/cpe24.11-cpu/opt/cce-18.0.1/darshan-runtime-3.4.6-ymnx2jlqwdsmjgdiu6ldpyxmcenq2nks/lib -DKOKKOS_DEPENDENCE -fno-gpu-rdc CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o -o test_proxy_coupling_xgc_client_fortran  -Wl,-rpath,/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/redev/install/lib64:/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/adios2/install/lib64:/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/perfstubs/install/lib:/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/omega_h/install/lib64:/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/kokkos/install/lib64 ../src/pcms/fortranapi/libpcmsfortranapi.a ../src/pcms/capi/libpcmscapi.a ../src/libpcmscore.a /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/redev/install/lib64/libredev.so /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/adios2/install/lib64/libadios2_cxx11_mpi.so.2.10.0 /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/adios2/install/lib64/libadios2_cxx11.so.2.10.0 /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/perfstubs/install/lib/libperfstubs.so -lm /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/omega_h/install/lib64/libomega_h.so /usr/lib64/libz.so /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/kokkos/install/lib64/libkokkoscontainers.so.4.7.99 /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/kokkos/install/lib64/libkokkosalgorithms.so.4.7.99 /opt/rocm-6.2.4/lib/libamdhip64.so.6.2.60204 --hip-link --offload-arch=gfx90a /opt/cray/pe/cce/18.0.1/cce-clang/x86_64/lib/clang/18/lib/linux/libclang_rt.builtins-x86_64.a /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/kokkos/install/lib64/libkokkossimd.so.4.7.99 /lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/kokkos/install/lib64/libkokkoscore.so.4.7.99 -ldl -Wl,-rpath-link,/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/adios2/install/lib64:/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/redev/install/lib64 
ld.lld: error: undefined symbol: mpi_init_
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> did you mean: mpp_init_
>>> defined in: /opt/cray/pe/cce/18.0.1/cce/x86_64/lib/pkgconfig/../libu.so

ld.lld: error: undefined symbol: mpi_comm_size_
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)

ld.lld: error: undefined symbol: mpi_comm_rank_
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)

ld.lld: error: undefined symbol: mpi_comm_split_
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)

ld.lld: error: undefined symbol: mpi_comm_free_
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)

ld.lld: error: undefined symbol: mpi_finalize_
>>> referenced by The Cpu Module
>>>               CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/test_proxy_coupling_xgc_client_fortran.f90.o:(main)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [test/CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/build.make:111: test/test_proxy_coupling_xgc_client_fortran] Error 1
make[2]: Leaving directory '/lustre/orion/csc679/scratch/cwsmith/pcmsDev/builds/AMD_GFX90A/pcms'
make[1]: *** [CMakeFiles/Makefile2:1399: test/CMakeFiles/test_proxy_coupling_xgc_client_fortran.dir/all] Error 2
```