### PR TITLE
Downgrade cmake-format to 0.6.11 in CI

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y clang-format-18
 
       - name: Install cmake-format
-        run: pip install PyYAML cmake-format==0.6.13
+        run: pip install PyYAML cmake-format==0.6.11
       
       - name: Check C++ code format
         run: |
@@ -54,7 +54,7 @@ jobs:
             fi
           done < <(find . -name "CMakeLists.txt" -o -name "*.cmake")
           if [ $EXIT_CODE -eq 1 ]; then
-            echo "Some CMake files are not properly formatted. Reformat with cmake-format 0.6.13."
+            echo "Some CMake files are not properly formatted. Reformat with cmake-format 0.6.11."
             exit 1
           fi
           echo "All CMake files are properly formatted"

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -7,25 +7,17 @@ on:
     branches: [ develop ]
 
 jobs:
-  format-check:
+  clang-format-check:
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-
       - name: Install clang-format
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-format-18
-
-      - name: Install cmake-format
-        run: pip install PyYAML cmake-format==0.6.11
       
       - name: Check C++ code format
         run: |
@@ -38,23 +30,39 @@ jobs:
             fi
           done < <(find . -name "*.cpp" -o -name "*.hpp" -o -name "*.c" -o -name "*.h" -o -name "*.cc" -o -name "*.cxx")
           if [ $EXIT_CODE -eq 1 ]; then
-            echo "Some C/C++ files are not properly formatted"
+            echo "Some C/C++ files are not properly formatted. Reformat with clang-format-18."
             exit 1
           fi
           echo "All C/C++ files are properly formatted"
+
+  cmake-format-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install cmake-format
+        run: |
+          pip install PyYAML cmake-format==0.6.11
       
       - name: Check CMake code format
         run: |
           EXIT_CODE=0
           while read file; do
-            if ! cmake-format --check "$file"; then
-              echo "$file is not properly formatted. Reformat with clang-format-18."
+            if ! cmake-format --check -c .cmake-format.yaml "$file"; then
+              echo "$file is not properly formatted"
               echo "Run: cmake-format -i $file"
               EXIT_CODE=1
             fi
           done < <(find . -name "CMakeLists.txt" -o -name "*.cmake")
           if [ $EXIT_CODE -eq 1 ]; then
-            echo "Some CMake files are not properly formatted. Reformat with cmake-format 0.6.11."
+            echo "Some CMake files are not properly formatted. Reformat with cmake-format 0.6.11"
             exit 1
           fi
           echo "All CMake files are properly formatted"


### PR DESCRIPTION
Downgrade cmake-format to 0.6.11 because it is the latest version in spack-packages.